### PR TITLE
Add template copy utility

### DIFF
--- a/bin/internal-scaffold.js
+++ b/bin/internal-scaffold.js
@@ -3,8 +3,10 @@
 
 const { Command } = require('commander');
 const inquirer = require('inquirer');
+const prompt = inquirer.createPromptModule();
 const fs = require('fs');
 const path = require('path');
+const { copyTemplates } = require('../lib/templateUtils');
 
 async function scaffoldProject(options) {
   try {
@@ -42,13 +44,17 @@ async function scaffoldProject(options) {
       },
     ];
 
-    const answers = await inquirer.prompt(questions);
+    const answers = await prompt(questions);
     const finalConfig = { ...config, ...answers };
 
     console.log('Scaffolding project with configuration:');
     console.log(JSON.stringify(finalConfig, null, 2));
 
-    // TODO: generate files and directories based on finalConfig
+    const templateDir = path.join(__dirname, '..', 'templates');
+    const projectDir = path.join(process.cwd(), finalConfig.projectName);
+
+    await copyTemplates(templateDir, projectDir, finalConfig);
+    console.log(`\nProject scaffolded at ${projectDir}`);
   } catch (err) {
     console.error(`Initialization failed: ${err.message}`);
     process.exit(1);

--- a/lib/templateUtils.js
+++ b/lib/templateUtils.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+async function copyTemplates(templateDir, destDir, variables = {}) {
+  await fs.promises.mkdir(destDir, { recursive: true });
+  const entries = await fs.promises.readdir(templateDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(templateDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      await copyTemplates(srcPath, destPath, variables);
+    } else {
+      let content = await fs.promises.readFile(srcPath, 'utf-8');
+      content = content.replace(/\{\{(.*?)\}\}/g, (_, key) => {
+        const k = key.trim();
+        return Object.prototype.hasOwnProperty.call(variables, k) ? variables[k] : '';
+      });
+      await fs.promises.writeFile(destPath, content);
+    }
+  }
+}
+
+module.exports = { copyTemplates };

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,3 @@
+# {{projectName}}
+
+This project uses {{database}} as the database.

--- a/templates/config/db.txt
+++ b/templates/config/db.txt
@@ -1,0 +1,1 @@
+Database: {{database}}


### PR DESCRIPTION
## Summary
- add `copyTemplates` util for injecting project variables
- scaffold projects from `templates` via CLI
- include example templates

## Testing
- `node bin/internal-scaffold.js init --config testconfig.json` *(fails: interactive prompt not provided)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb877b9083258336d1aa367e79a1