### PR TITLE
Implement architecture-based structure generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This tool helps teams quickly set up new projects by automating:
 ## 🧠 Features
 
 - 📋 CLI-based or Web UI setup
-- 📁 Auto-generated folder structures
+- 📁 Auto-generated folder structures (via `generateStructure`)
 - 🔐 Auth (MSAL, OAuth2, custom)
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
 - 🧱 Architecture patterns (Layered, DDD, Microservice-ready)

--- a/bin/internal-scaffold.js
+++ b/bin/internal-scaffold.js
@@ -7,6 +7,7 @@ const prompt = inquirer.createPromptModule();
 const fs = require('fs');
 const path = require('path');
 const { copyTemplates } = require('../lib/templateUtils');
+const { generateStructure } = require('../lib/structureGenerator');
 
 async function scaffoldProject(options) {
   try {
@@ -42,6 +43,12 @@ async function scaffoldProject(options) {
         message: 'Database:',
         default: config.database,
       },
+      {
+        type: 'input',
+        name: 'architecture',
+        message: 'Architecture pattern:',
+        default: config.architecture || 'layered',
+      },
     ];
 
     const answers = await prompt(questions);
@@ -54,6 +61,10 @@ async function scaffoldProject(options) {
     const projectDir = path.join(process.cwd(), finalConfig.projectName);
 
     await copyTemplates(templateDir, projectDir, finalConfig);
+    await generateStructure({
+      projectName: finalConfig.projectName,
+      architecture: finalConfig.architecture || 'layered'
+    });
     console.log(`\nProject scaffolded at ${projectDir}`);
   } catch (err) {
     console.error(`Initialization failed: ${err.message}`);

--- a/lib/structureGenerator.js
+++ b/lib/structureGenerator.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+function getArchitectureTree(name) {
+  const trees = {
+    clean: {
+      src: {
+        domain: {},
+        application: {},
+        infrastructure: {},
+        interfaces: {}
+      },
+      tests: {}
+    },
+    layered: {
+      src: {
+        controllers: {},
+        services: {},
+        models: {},
+        repositories: {}
+      }
+    }
+  };
+  return trees[name.toLowerCase()] || trees.layered;
+}
+
+async function createTree(baseDir, tree) {
+  for (const [name, value] of Object.entries(tree)) {
+    const target = path.join(baseDir, name);
+    if (typeof value === 'string') {
+      await fs.promises.mkdir(path.dirname(target), { recursive: true });
+      await fs.promises.writeFile(target, value);
+    } else {
+      await fs.promises.mkdir(target, { recursive: true });
+      await createTree(target, value);
+    }
+  }
+}
+
+async function generateStructure(config) {
+  const projectDir = path.resolve(process.cwd(), config.projectName);
+  const tree = getArchitectureTree(config.architecture || 'layered');
+  await createTree(projectDir, tree);
+}
+
+module.exports = { generateStructure };


### PR DESCRIPTION
## Summary
- create `structureGenerator.js` utility for generating architecture folders
- prompt for `architecture` in the CLI and invoke `generateStructure`
- mention new function in README features

## Testing
- `npm test` *(fails: Missing script)*
- `node bin/internal-scaffold.js init --help`

------
https://chatgpt.com/codex/tasks/task_e_685eeecf8360832580b5606e1301bf9d