### PR TITLE
Update GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,13 +14,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Generate docs
         run: npm run update-docs
-      - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
   deploy:
@@ -31,4 +31,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- use `actions/checkout@v4`
- update Pages actions to latest versions

## Testing
- `npm ci` *(fails: package-lock.json missing)*
- `npm install`
- `npm run update-docs` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_685ef090e38083259416b4cb9b21dec6