### PR TITLE
Fix docs generation script

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ title: Internal Project Scaffolding
 ---
 
 <style>
-body { font-family: Arial, sans-serif; line-height: 1.6; max-width: 800px; margin: 2rem auto; }
-h1, h2, h3 { color: #333; }
+  body { font-family: Arial, sans-serif; line-height: 1.6; max-width: 800px; margin: 2rem auto; }
+  h1, h2, h3 { color: #333; }
 </style>
 
 # Internal Project Scaffolding Tool
@@ -30,7 +30,7 @@ This tool helps teams quickly set up new projects by automating:
 ## 🧠 Features
 
 - 📋 CLI-based or Web UI setup
-- 📁 Auto-generated folder structures
+- 📁 Auto-generated folder structures (via `generateStructure`)
 - 🔐 Auth (MSAL, OAuth2, custom)
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
 - 🧱 Architecture patterns (Layered, DDD, Microservice-ready)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "internal-scaffold": "./bin/internal-scaffold.js"
   },
   "scripts": {
-    "update-docs": "ts-node update-docs.ts"
+    "update-docs": "node update-docs.js"
   },
   "dependencies": {
     "commander": "^11.0.0",

--- a/update-docs.js
+++ b/update-docs.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+const { readFileSync, writeFileSync } = require("fs");
 
 const readme = readFileSync('README.md', 'utf8');
 


### PR DESCRIPTION
## Summary
- replace `ts-node` with plain Node.js for docs generation
- update docs to include latest README features

## Testing
- `npm run update-docs`


------
https://chatgpt.com/codex/tasks/task_e_685ef649b86083258450f1d7da2ea202