### PR TITLE
docs: clarify GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Generate docs
         run: npm run update-docs
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ npx internal-scaffold init --config scaffold.config.json
 
 ---
 
+## 📄 GitHub Pages Setup
+
+This repository includes a workflow that publishes the contents of the `docs` directory to GitHub Pages. Make sure Pages is enabled for the repo or set `enablement: true` in `.github/workflows/pages.yml` so the workflow can enable it automatically.
+
+---
+
 ## 🔐 Internal Usage Only
 
 This is an internal tool for rapid scaffolding and prototyping across teams. It is not intended for public use.

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,12 @@ npx internal-scaffold init --config scaffold.config.json
 
 ---
 
+## 📄 GitHub Pages Setup
+
+This repository includes a workflow that publishes the contents of the `docs` directory to GitHub Pages. Make sure Pages is enabled for the repo or set `enablement: true` in `.github/workflows/pages.yml` so the workflow can enable it automatically.
+
+---
+
 ## 🔐 Internal Usage Only
 
 This is an internal tool for rapid scaffolding and prototyping across teams. It is not intended for public use.


### PR DESCRIPTION
## Summary
- enable automatic Pages creation in the workflow
- document how to enable GitHub Pages
- regenerate docs

## Testing
- `npm ci`
- `npm run update-docs`


------
https://chatgpt.com/codex/tasks/task_e_685ef8c9c4cc8325b7a2bfbeab11e5ca