### PR TITLE
Add optional middleware setup for API template

### DIFF
--- a/templates/api/appsettings.json
+++ b/templates/api/appsettings.json
@@ -10,7 +10,9 @@
   },
   "Features": {
     "EnableAuth": {{enableAuth}},
-    "EnableEf": {{enableEf}}
+    "EnableEf": {{enableEf}},
+    "EnableSwagger": {{enableSwagger}},
+    "EnableCors": {{enableCors}}
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- expand `appsettings.json` template with flags for Swagger and CORS
- replace API `Program.cs` with a more complete version
  - sets up Swagger, CORS, EF, and auth depending on configuration
  - adds a global error-handling middleware

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f03fa79048325afd5a17786283832