### PR TITLE
Add optional Refit HTTP client service

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This tool helps teams quickly set up new projects by automating:
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
 - 🧱 Architecture patterns (Layered, DDD, Microservice-ready)
 - ⚙️ Optional services (Hangfire, Swagger, Health checks, etc.)
+- 🌐 Typed HTTP clients with Refit ([example](docs/refit-http-clients.md))
 - 📦 Package.json, Dockerfile, `.editorconfig`, `.gitignore`
 - 🚀 Azure DevOps/GitHub Actions CI templates
 - 🧪 Testing setup (xUnit, Jest, Playwright)
@@ -90,8 +91,12 @@ Define your default setup in `scaffold.config.json`:
   "auth": "MSAL",
   "enableAuth": true,
   "enableEf": true,
+  "enableHttpClients": true,
   "architecture": "Clean",
-  "features": ["Hangfire", "Swagger", "HealthCheck"]
+  "features": ["Hangfire", "Swagger", "HealthCheck"],
+  "serviceUrls": {
+    "MyApi": "https://example.com"
+  }
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ This tool helps teams quickly set up new projects by automating:
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
 - 🧱 Architecture patterns (Layered, DDD, Microservice-ready)
 - ⚙️ Optional services (Hangfire, Swagger, Health checks, etc.)
+- 🌐 Typed HTTP clients with Refit ([example](./refit-http-clients.md))
 - 📦 Package.json, Dockerfile, `.editorconfig`, `.gitignore`
 - 🚀 Azure DevOps/GitHub Actions CI templates
 - 🧪 Testing setup (xUnit, Jest, Playwright)
@@ -99,8 +100,12 @@ Define your default setup in `scaffold.config.json`:
   "auth": "MSAL",
   "enableAuth": true,
   "enableEf": true,
+  "enableHttpClients": true,
   "architecture": "Clean",
-  "features": ["Hangfire", "Swagger", "HealthCheck"]
+  "features": ["Hangfire", "Swagger", "HealthCheck"],
+  "serviceUrls": {
+    "MyApi": "https://example.com"
+  }
 }
 ```
 

--- a/docs/refit-http-clients.md
+++ b/docs/refit-http-clients.md
@@ -1,0 +1,32 @@
+# Shared HTTP Client Service
+
+When `enableHttpClients` is set to `true` in `scaffold.config.json`, the API template registers a generic Refit-based HTTP client. Base URLs are read from the `ServiceUrls` section of `appsettings.json`.
+
+```csharp
+// Program.cs fragment
+if (enableHttpClients)
+{
+    builder.Services.AddHttpClient();
+    builder.Services.AddTransient(typeof(IRefitHttpClientService<>), typeof(RefitHttpClientService<>));
+}
+```
+
+Interfaces for remote APIs can be defined and resolved via `IRefitHttpClientService<T>`.
+
+```csharp
+public interface IWeatherApi
+{
+    [Get("/forecast")] Task<Forecast[]> GetForecastAsync();
+}
+
+public class WeatherService
+{
+    private readonly IWeatherApi _api;
+    public WeatherService(IRefitHttpClientService<IWeatherApi> service)
+    {
+        _api = service.Api;
+    }
+
+    public Task<Forecast[]> GetAsync() => _api.GetForecastAsync();
+}
+```

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.validateConfig = validateConfig;
 const allowedArchitectures = ["clean", "layered"];
 function validateConfig(config) {
+    var _a, _b, _c;
     const errors = [];
     if (!config.projectName) {
         errors.push("projectName is required");
@@ -30,7 +31,8 @@ function validateConfig(config) {
         database: config.database,
         architecture,
         preset: config.preset,
-        enableAuth: config.enableAuth ?? false,
-        enableEf: config.enableEf ?? false,
+        enableAuth: (_a = config.enableAuth) !== null && _a !== void 0 ? _a : false,
+        enableEf: (_b = config.enableEf) !== null && _b !== void 0 ? _b : false,
+        enableHttpClients: (_c = config.enableHttpClients) !== null && _c !== void 0 ? _c : false,
     };
 }

--- a/lib/configValidator.ts
+++ b/lib/configValidator.ts
@@ -7,6 +7,7 @@ export interface ScaffoldConfig {
   preset?: string;
   enableAuth?: boolean;
   enableEf?: boolean;
+  enableHttpClients?: boolean;
 }
 
 export interface ValidatedConfig {
@@ -18,6 +19,7 @@ export interface ValidatedConfig {
   preset?: string;
   enableAuth: boolean;
   enableEf: boolean;
+  enableHttpClients: boolean;
 }
 
 const allowedArchitectures = ["clean", "layered"];
@@ -55,5 +57,6 @@ export function validateConfig(config: ScaffoldConfig): ValidatedConfig {
     preset: config.preset,
     enableAuth: config.enableAuth ?? false,
     enableEf: config.enableEf ?? false,
+    enableHttpClients: config.enableHttpClients ?? false,
   };
 }

--- a/templates/api/Program.cs
+++ b/templates/api/Program.cs
@@ -10,6 +10,7 @@ var enableAuth = features.GetValue<bool>("EnableAuth");
 var enableEf = features.GetValue<bool>("EnableEf");
 var enableSwagger = features.GetValue<bool>("EnableSwagger");
 var enableCors = features.GetValue<bool>("EnableCors");
+var enableHttpClients = features.GetValue<bool>("EnableHttpClients");
 
 if (enableAuth)
 {
@@ -33,6 +34,12 @@ if (enableEf)
 }
 
 builder.Services.AddControllers();
+
+if (enableHttpClients)
+{
+    builder.Services.AddHttpClient();
+    builder.Services.AddTransient(typeof(IRefitHttpClientService<>), typeof(RefitHttpClientService<>));
+}
 
 if (enableCors)
 {

--- a/templates/api/Services/RefitHttpClientService.cs
+++ b/templates/api/Services/RefitHttpClientService.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using Microsoft.Extensions.Http;
+using Refit;
+
+public interface IRefitHttpClientService<TClient> where TClient : class
+{
+    TClient Api { get; }
+}
+
+public class RefitHttpClientService<TClient> : IRefitHttpClientService<TClient> where TClient : class
+{
+    public TClient Api { get; }
+
+    public RefitHttpClientService(IHttpClientFactory factory, IConfiguration config)
+    {
+        var baseUrl = config[$"ServiceUrls:{typeof(TClient).Name}"]; 
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException($"Base URL for {typeof(TClient).Name} not configured");
+        }
+        var httpClient = factory.CreateClient(typeof(TClient).Name);
+        httpClient.BaseAddress = new Uri(baseUrl);
+        Api = RestService.For<TClient>(httpClient);
+    }
+}

--- a/templates/api/appsettings.json
+++ b/templates/api/appsettings.json
@@ -12,7 +12,11 @@
     "EnableAuth": {{enableAuth}},
     "EnableEf": {{enableEf}},
     "EnableSwagger": {{enableSwagger}},
-    "EnableCors": {{enableCors}}
+    "EnableCors": {{enableCors}},
+    "EnableHttpClients": {{enableHttpClients}}
+  },
+  "ServiceUrls": {
+    "ExampleApi": "https://api.example.com"
   },
   "Logging": {
     "LogLevel": {

--- a/tests/configValidator.test.ts
+++ b/tests/configValidator.test.ts
@@ -12,6 +12,7 @@ describe('validateConfig', () => {
     expect(result.architecture).toBe('layered');
     expect(result.enableAuth).toBe(false);
     expect(result.enableEf).toBe(false);
+    expect(result.enableHttpClients).toBe(false);
   });
 
   it('throws if required fields missing', () => {


### PR DESCRIPTION
## Summary
- add generic RefitHttpClientService template
- register service via feature flag in Program.cs
- expose EnableHttpClients and ServiceUrls in appsettings.json
- document feature in README and docs
- update config validator and tests for new flag
- add example docs on Refit HTTP clients

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f062e92248325993c17c427e50bf6