### PR TITLE
Fix config flag handling

### DIFF
--- a/bin/internal-scaffold.js
+++ b/bin/internal-scaffold.js
@@ -67,6 +67,18 @@ async function scaffoldProject(options) {
         message: 'Use EF Core?',
         default: config.enableEf || false,
       },
+      {
+        type: 'confirm',
+        name: 'enableSwagger',
+        message: 'Enable Swagger?',
+        default: config.enableSwagger || false,
+      },
+      {
+        type: 'confirm',
+        name: 'enableCors',
+        message: 'Enable CORS?',
+        default: config.enableCors || false,
+      },
     ];
 
     const answers = await prompt(questions);
@@ -74,12 +86,14 @@ async function scaffoldProject(options) {
 
     let efProvider = '';
     let connectionString = '';
-    if (finalConfig.enableEf) {
-      if (/sql server/i.test(finalConfig.database)) {
-        efProvider = 'UseSqlServer';
+    if (/sql server/i.test(finalConfig.database)) {
+      efProvider = 'UseSqlServer';
+      if (finalConfig.enableEf) {
         connectionString = `Server=localhost;Database=${finalConfig.projectName};Trusted_Connection=True;TrustServerCertificate=True;`;
-      } else if (/postgres/i.test(finalConfig.database)) {
-        efProvider = 'UseNpgsql';
+      }
+    } else if (/postgres/i.test(finalConfig.database)) {
+      efProvider = 'UseNpgsql';
+      if (finalConfig.enableEf) {
         connectionString = `Host=localhost;Database=${finalConfig.projectName};Username=postgres;Password=postgres`;
       }
     }

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.validateConfig = validateConfig;
 const allowedArchitectures = ["clean", "layered"];
 function validateConfig(config) {
-    var _a, _b, _c;
+    var _a, _b, _c, _d, _e;
     const errors = [];
     if (!config.projectName) {
         errors.push("projectName is required");
@@ -34,5 +34,7 @@ function validateConfig(config) {
         enableAuth: (_a = config.enableAuth) !== null && _a !== void 0 ? _a : false,
         enableEf: (_b = config.enableEf) !== null && _b !== void 0 ? _b : false,
         enableHttpClients: (_c = config.enableHttpClients) !== null && _c !== void 0 ? _c : false,
+        enableSwagger: (_d = config.enableSwagger) !== null && _d !== void 0 ? _d : false,
+        enableCors: (_e = config.enableCors) !== null && _e !== void 0 ? _e : false,
     };
 }

--- a/lib/configValidator.ts
+++ b/lib/configValidator.ts
@@ -8,6 +8,8 @@ export interface ScaffoldConfig {
   enableAuth?: boolean;
   enableEf?: boolean;
   enableHttpClients?: boolean;
+  enableSwagger?: boolean;
+  enableCors?: boolean;
 }
 
 export interface ValidatedConfig {
@@ -20,6 +22,8 @@ export interface ValidatedConfig {
   enableAuth: boolean;
   enableEf: boolean;
   enableHttpClients: boolean;
+  enableSwagger: boolean;
+  enableCors: boolean;
 }
 
 const allowedArchitectures = ["clean", "layered"];
@@ -58,5 +62,7 @@ export function validateConfig(config: ScaffoldConfig): ValidatedConfig {
     enableAuth: config.enableAuth ?? false,
     enableEf: config.enableEf ?? false,
     enableHttpClients: config.enableHttpClients ?? false,
+    enableSwagger: config.enableSwagger ?? false,
+    enableCors: config.enableCors ?? false,
   };
 }

--- a/tests/configValidator.test.ts
+++ b/tests/configValidator.test.ts
@@ -13,6 +13,8 @@ describe('validateConfig', () => {
     expect(result.enableAuth).toBe(false);
     expect(result.enableEf).toBe(false);
     expect(result.enableHttpClients).toBe(false);
+    expect(result.enableSwagger).toBe(false);
+    expect(result.enableCors).toBe(false);
   });
 
   it('throws if required fields missing', () => {


### PR DESCRIPTION
## Summary
- extend config validation to include `enableSwagger` and `enableCors`
- update CLI prompts and EF provider logic
- adjust tests for new defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f0a2f392483258d53872549520041