### PR TITLE
Add config examples for common setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Then run:
 npx internal-scaffold init --config scaffold.config.json
 ```
 
+A set of ready-to-use configuration files covering common backend, frontend,
+and database combinations lives in the `configs/` directory. You can pass any of
+these files directly to the CLI:
+
+```bash
+npx internal-scaffold init --config configs/dotnet-react-sqlserver.json
+```
+
 ---
 
 ## 💡 Future Roadmap

--- a/configs/dotnet-blazor-mongodb.json
+++ b/configs/dotnet-blazor-mongodb.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "dotnet",
+  "frontend": "blazor",
+  "database": "mongodb",
+  "auth": "MSAL",
+  "enableAuth": true,
+  "enableEf": true,
+  "enableHttpClients": true,
+  "architecture": "clean"
+}

--- a/configs/dotnet-blazor-postgres.json
+++ b/configs/dotnet-blazor-postgres.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "dotnet",
+  "frontend": "blazor",
+  "database": "postgres",
+  "auth": "MSAL",
+  "enableAuth": true,
+  "enableEf": true,
+  "enableHttpClients": true,
+  "architecture": "clean"
+}

--- a/configs/dotnet-blazor-sqlserver.json
+++ b/configs/dotnet-blazor-sqlserver.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "dotnet",
+  "frontend": "blazor",
+  "database": "sqlserver",
+  "auth": "MSAL",
+  "enableAuth": true,
+  "enableEf": true,
+  "enableHttpClients": true,
+  "architecture": "clean"
+}

--- a/configs/dotnet-react-mongodb.json
+++ b/configs/dotnet-react-mongodb.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "dotnet",
+  "frontend": "react",
+  "database": "mongodb",
+  "auth": "MSAL",
+  "enableAuth": true,
+  "enableEf": true,
+  "enableHttpClients": true,
+  "architecture": "clean"
+}

--- a/configs/dotnet-react-postgres.json
+++ b/configs/dotnet-react-postgres.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "dotnet",
+  "frontend": "react",
+  "database": "postgres",
+  "auth": "MSAL",
+  "enableAuth": true,
+  "enableEf": true,
+  "enableHttpClients": true,
+  "architecture": "clean"
+}

--- a/configs/dotnet-react-sqlserver.json
+++ b/configs/dotnet-react-sqlserver.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "dotnet",
+  "frontend": "react",
+  "database": "sqlserver",
+  "auth": "MSAL",
+  "enableAuth": true,
+  "enableEf": true,
+  "enableHttpClients": true,
+  "architecture": "clean"
+}

--- a/configs/node-blazor-mongodb.json
+++ b/configs/node-blazor-mongodb.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "node",
+  "frontend": "blazor",
+  "database": "mongodb",
+  "auth": "OAuth2",
+  "enableAuth": true,
+  "enableEf": false,
+  "enableHttpClients": true,
+  "architecture": "layered"
+}

--- a/configs/node-blazor-postgres.json
+++ b/configs/node-blazor-postgres.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "node",
+  "frontend": "blazor",
+  "database": "postgres",
+  "auth": "OAuth2",
+  "enableAuth": true,
+  "enableEf": false,
+  "enableHttpClients": true,
+  "architecture": "layered"
+}

--- a/configs/node-blazor-sqlserver.json
+++ b/configs/node-blazor-sqlserver.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "node",
+  "frontend": "blazor",
+  "database": "sqlserver",
+  "auth": "OAuth2",
+  "enableAuth": true,
+  "enableEf": false,
+  "enableHttpClients": true,
+  "architecture": "layered"
+}

--- a/configs/node-react-mongodb.json
+++ b/configs/node-react-mongodb.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "node",
+  "frontend": "react",
+  "database": "mongodb",
+  "auth": "OAuth2",
+  "enableAuth": true,
+  "enableEf": false,
+  "enableHttpClients": true,
+  "architecture": "layered"
+}

--- a/configs/node-react-postgres.json
+++ b/configs/node-react-postgres.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "node",
+  "frontend": "react",
+  "database": "postgres",
+  "auth": "OAuth2",
+  "enableAuth": true,
+  "enableEf": false,
+  "enableHttpClients": true,
+  "architecture": "layered"
+}

--- a/configs/node-react-sqlserver.json
+++ b/configs/node-react-sqlserver.json
@@ -1,0 +1,11 @@
+{
+  "projectName": "sample-app",
+  "backend": "node",
+  "frontend": "react",
+  "database": "sqlserver",
+  "auth": "OAuth2",
+  "enableAuth": true,
+  "enableEf": false,
+  "enableHttpClients": true,
+  "architecture": "layered"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ This tool helps teams quickly set up new projects by automating:
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
 - 🧱 Architecture patterns (Layered, DDD, Microservice-ready)
 - ⚙️ Optional services (Hangfire, Swagger, Health checks, etc.)
-- 🌐 Typed HTTP clients with Refit ([example](./refit-http-clients.md))
+- 🌐 Typed HTTP clients with Refit ([example](docs/refit-http-clients.md))
 - 📦 Package.json, Dockerfile, `.editorconfig`, `.gitignore`
 - 🚀 Azure DevOps/GitHub Actions CI templates
 - 🧪 Testing setup (xUnit, Jest, Playwright)
@@ -108,7 +108,7 @@ Define your default setup in `scaffold.config.json`:
   }
 }
 ```
-Any optional flag (such as `enableAuth` or `enableEf`) removes all related files and packages when set to `false`. This means, for example, that disabling `enableAuth` leaves out every authentication package and configuration from the generated project.
+Any optional flag (such as `enableAuth` or `enableEf`) removes all related files and packages when set to `false`. For instance, with `enableAuth: false` there will be no authentication configuration or dependencies anywhere in the generated project.
 
 
 Set the environment variable `REACT_APP_ENABLE_AUTH=true` in the React app to toggle authentication.
@@ -116,6 +116,14 @@ Set the environment variable `REACT_APP_ENABLE_AUTH=true` in the React app to to
 Then run:
 ```bash
 npx internal-scaffold init --config scaffold.config.json
+```
+
+A set of ready-to-use configuration files covering common backend, frontend,
+and database combinations lives in the `configs/` directory. You can pass any of
+these files directly to the CLI:
+
+```bash
+npx internal-scaffold init --config configs/dotnet-react-sqlserver.json
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add a `configs` directory with sample config JSON files
- document new config examples in README
- update generated docs

## Testing
- `npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685f0d682a688325a747685d96188b0e