### PR TITLE
Add GraphQL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Internal Project Scaffolding Tool is designed to bootstrap internal applicat
 This tool helps teams quickly set up new projects by automating:
 - Authentication & Authorization
 - Database integration
-- API layers and routing
+- API layers and routing (REST or GraphQL)
 - UI framework setup (React + Tailwind)
 - CI/CD pipelines
 - Environment configurations
@@ -26,7 +26,9 @@ This tool helps teams quickly set up new projects by automating:
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
 - 🧱 Architecture patterns (Layered, DDD, Microservice-ready)
 - ⚙️ Optional services (Hangfire, Swagger, Health checks, etc.)
+- 🌐 REST or GraphQL API templates
 - 🌐 Typed HTTP clients with Refit ([example](docs/refit-http-clients.md))
+- 📖 GraphQL setup ([guide](docs/graphql-dotnet-react.md))
 - 📦 Package.json, Dockerfile, `.editorconfig`, `.gitignore`
 - 🚀 Azure DevOps/GitHub Actions CI templates
 - 🧪 Testing setup (xUnit, Jest, Playwright)
@@ -88,6 +90,7 @@ Define your default setup in `scaffold.config.json`:
   "frontend": "React",
   "backend": ".NET 8",
   "database": "SQL Server",
+  "apiType": "rest",
   "auth": "MSAL",
   "enableAuth": true,
   "enableEf": true,

--- a/bin/internal-scaffold.js
+++ b/bin/internal-scaffold.js
@@ -51,6 +51,12 @@ async function scaffoldProject(options) {
       },
       {
         type: 'input',
+        name: 'apiType',
+        message: 'API type (rest/graphql):',
+        default: config.apiType || 'rest',
+      },
+      {
+        type: 'input',
         name: 'architecture',
         message: 'Architecture pattern:',
         default: config.architecture || 'layered',

--- a/configs/dotnet-react-graphql-sqlserver.json
+++ b/configs/dotnet-react-graphql-sqlserver.json
@@ -1,0 +1,12 @@
+{
+  "projectName": "graphql-app",
+  "backend": "dotnet",
+  "frontend": "react",
+  "database": "sqlserver",
+  "apiType": "graphql",
+  "auth": "MSAL",
+  "enableAuth": true,
+  "enableEf": true,
+  "enableHttpClients": true,
+  "architecture": "clean"
+}

--- a/docs/graphql-dotnet-react.md
+++ b/docs/graphql-dotnet-react.md
@@ -1,0 +1,62 @@
+# GraphQL with .NET Backend and React Frontend
+
+This guide explains how to scaffold a project that uses GraphQL for the API layer while keeping React on the frontend and .NET on the backend.
+
+## .NET Backend
+
+We recommend using [Hot Chocolate](https://chillicream.com/docs/hotchocolate/v13) for GraphQL support in .NET. After generating the project with `apiType` set to `graphql`, add the Hot Chocolate NuGet packages and configure the schema in `Program.cs`:
+
+```csharp
+builder.Services
+    .AddGraphQLServer()
+    .AddQueryType<Query>();
+
+app.MapGraphQL();
+```
+
+Define your GraphQL types such as `Query` in the `api` folder. The scaffold will still generate controller stubs which can be removed when using GraphQL exclusively.
+
+## React Frontend
+
+For React applications we suggest [Apollo Client](https://www.apollographql.com/docs/react/) to consume the GraphQL API. Install the packages and create an `ApolloProvider` near the root of your app:
+
+```tsx
+import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
+
+const client = new ApolloClient({
+  uri: '/graphql',
+  cache: new InMemoryCache(),
+});
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>
+  </React.StrictMode>
+);
+```
+
+With this setup you can write queries using `useQuery` and mutations with `useMutation`.
+
+## Config Example
+
+Use the following `scaffold.config.json` to generate a project pre-configured for GraphQL:
+
+```json
+{
+  "projectName": "graphql-app",
+  "backend": "dotnet",
+  "frontend": "react",
+  "database": "sqlserver",
+  "apiType": "graphql",
+  "enableAuth": true,
+  "enableEf": true
+}
+```
+
+Run the CLI with `--config` to scaffold the project:
+
+```bash
+npx internal-scaffold init --config configs/dotnet-react-graphql-sqlserver.json
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ The Internal Project Scaffolding Tool is designed to bootstrap internal applicat
 This tool helps teams quickly set up new projects by automating:
 - Authentication & Authorization
 - Database integration
-- API layers and routing
+- API layers and routing (REST or GraphQL)
 - UI framework setup (React + Tailwind)
 - CI/CD pipelines
 - Environment configurations
@@ -35,7 +35,9 @@ This tool helps teams quickly set up new projects by automating:
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
 - 🧱 Architecture patterns (Layered, DDD, Microservice-ready)
 - ⚙️ Optional services (Hangfire, Swagger, Health checks, etc.)
+- 🌐 REST or GraphQL API templates
 - 🌐 Typed HTTP clients with Refit ([example](docs/refit-http-clients.md))
+- 📖 GraphQL setup ([guide](docs/graphql-dotnet-react.md))
 - 📦 Package.json, Dockerfile, `.editorconfig`, `.gitignore`
 - 🚀 Azure DevOps/GitHub Actions CI templates
 - 🧪 Testing setup (xUnit, Jest, Playwright)
@@ -97,6 +99,7 @@ Define your default setup in `scaffold.config.json`:
   "frontend": "React",
   "backend": ".NET 8",
   "database": "SQL Server",
+  "apiType": "rest",
   "auth": "MSAL",
   "enableAuth": true,
   "enableEf": true,

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.validateConfig = validateConfig;
 const allowedArchitectures = ["clean", "layered"];
+const allowedApiTypes = ["rest", "graphql"];
 function validateConfig(config) {
     var _a, _b, _c, _d, _e;
     const errors = [];
@@ -21,6 +22,10 @@ function validateConfig(config) {
     if (!allowedArchitectures.includes(architecture)) {
         errors.push(`architecture must be one of ${allowedArchitectures.join(', ')}`);
     }
+    const apiType = config.apiType || "rest";
+    if (!allowedApiTypes.includes(apiType)) {
+        errors.push(`apiType must be one of ${allowedApiTypes.join(', ')}`);
+    }
     if (errors.length) {
         throw new Error("Config validation failed: " + errors.join(", "));
     }
@@ -30,6 +35,7 @@ function validateConfig(config) {
         frontend: config.frontend,
         database: config.database,
         architecture,
+        apiType,
         preset: config.preset,
         enableAuth: (_a = config.enableAuth) !== null && _a !== void 0 ? _a : false,
         enableEf: (_b = config.enableEf) !== null && _b !== void 0 ? _b : false,

--- a/lib/configValidator.ts
+++ b/lib/configValidator.ts
@@ -4,6 +4,7 @@ export interface ScaffoldConfig {
   frontend?: string;
   database?: string;
   architecture?: string;
+  apiType?: string;
   preset?: string;
   enableAuth?: boolean;
   enableEf?: boolean;
@@ -18,6 +19,7 @@ export interface ValidatedConfig {
   frontend: string;
   database: string;
   architecture: string;
+  apiType: string;
   preset?: string;
   enableAuth: boolean;
   enableEf: boolean;
@@ -27,6 +29,7 @@ export interface ValidatedConfig {
 }
 
 const allowedArchitectures = ["clean", "layered"];
+const allowedApiTypes = ["rest", "graphql"];
 
 export function validateConfig(config: ScaffoldConfig): ValidatedConfig {
   const errors: string[] = [];
@@ -48,6 +51,11 @@ export function validateConfig(config: ScaffoldConfig): ValidatedConfig {
     errors.push(`architecture must be one of ${allowedArchitectures.join(', ')}`);
   }
 
+  const apiType = config.apiType || "rest";
+  if (!allowedApiTypes.includes(apiType)) {
+    errors.push(`apiType must be one of ${allowedApiTypes.join(', ')}`);
+  }
+
   if (errors.length) {
     throw new Error("Config validation failed: " + errors.join(", "));
   }
@@ -58,6 +66,7 @@ export function validateConfig(config: ScaffoldConfig): ValidatedConfig {
     frontend: config.frontend!,
     database: config.database!,
     architecture,
+    apiType,
     preset: config.preset,
     enableAuth: config.enableAuth ?? false,
     enableEf: config.enableEf ?? false,

--- a/tests/configValidator.test.ts
+++ b/tests/configValidator.test.ts
@@ -10,6 +10,7 @@ describe('validateConfig', () => {
     };
     const result = validateConfig(input);
     expect(result.architecture).toBe('layered');
+    expect(result.apiType).toBe('rest');
     expect(result.enableAuth).toBe(false);
     expect(result.enableEf).toBe(false);
     expect(result.enableHttpClients).toBe(false);
@@ -30,5 +31,16 @@ describe('validateConfig', () => {
       architecture: 'wrong'
     };
     expect(() => validateConfig(input)).toThrow('architecture');
+  });
+
+  it('throws for invalid apiType', () => {
+    const input: ScaffoldConfig = {
+      projectName: 'a',
+      backend: 'b',
+      frontend: 'c',
+      database: 'd',
+      apiType: 'soap'
+    };
+    expect(() => validateConfig(input)).toThrow('apiType');
   });
 });


### PR DESCRIPTION
## Summary
- support `apiType` in config validator
- prompt for API type in CLI
- document GraphQL setup for .NET and React
- provide GraphQL sample config
- update tests for new option

## Testing
- `npm install --silent`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685f6db9a18c8325abe122aad6d92bf8