### PR TITLE
Add architecture-specific templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This tool helps teams quickly set up new projects by automating:
 - CI/CD pipelines
 - Environment configurations
 - Linting and formatting rules
-- Code structure based on selected architecture (e.g., Clean Architecture, Onion Architecture, etc.)
+- Code structure based on selected architecture (e.g., Clean, Onion, DDD)
 
 ---
 
@@ -24,7 +24,7 @@ This tool helps teams quickly set up new projects by automating:
 - 📁 Auto-generated folder structures (via `generateStructure`)
 - 🔐 Auth (MSAL, OAuth2, custom)
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
-- 🧱 Architecture patterns (Layered, DDD, Microservice-ready)
+- 🧱 Architecture patterns (Layered, Clean, Onion, DDD)
 - ⚙️ Optional services (Hangfire, Swagger, Health checks, etc.)
 - 🌐 REST or GraphQL API templates
 - 🌐 Typed HTTP clients with Refit ([example](docs/refit-http-clients.md))
@@ -33,6 +33,10 @@ This tool helps teams quickly set up new projects by automating:
 - 🚀 Azure DevOps/GitHub Actions CI templates
 - 🧪 Testing setup (xUnit, Jest, Playwright)
 - 🎨 UI with ShadCN + TailwindCSS (React Frontend)
+
+### Architecture Templates
+
+This scaffold includes template sets for **Clean**, **Layered**, **Onion**, and **DDD** architectures. Each architecture provides compatible backend and frontend folders under `templates/<architecture>`.
 
 ---
 

--- a/bin/internal-scaffold.js
+++ b/bin/internal-scaffold.js
@@ -107,10 +107,14 @@ async function scaffoldProject(options) {
     console.log('Scaffolding project with configuration:');
     console.log(JSON.stringify({ ...finalConfig, efProvider, connectionString }, null, 2));
 
-    const templateDir = path.join(__dirname, '..', 'templates');
+    const baseTemplateDir = path.join(__dirname, '..', 'templates');
+    const archTemplateDir = path.join(baseTemplateDir, finalConfig.architecture);
     const projectDir = path.join(process.cwd(), finalConfig.projectName);
 
-    await copyTemplates(templateDir, projectDir, { ...finalConfig, efProvider, connectionString });
+    await copyTemplates(baseTemplateDir, projectDir, { ...finalConfig, efProvider, connectionString });
+    if (fs.existsSync(archTemplateDir)) {
+      await copyTemplates(archTemplateDir, projectDir, { ...finalConfig, efProvider, connectionString });
+    }
     await generateStructure({
       projectName: finalConfig.projectName,
       architecture: finalConfig.architecture

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ This tool helps teams quickly set up new projects by automating:
 - CI/CD pipelines
 - Environment configurations
 - Linting and formatting rules
-- Code structure based on selected architecture (e.g., Clean Architecture, Onion Architecture, etc.)
+- Code structure based on selected architecture (e.g., Clean, Onion, DDD)
 
 ---
 
@@ -33,7 +33,7 @@ This tool helps teams quickly set up new projects by automating:
 - 📁 Auto-generated folder structures (via `generateStructure`)
 - 🔐 Auth (MSAL, OAuth2, custom)
 - 🗃️ DB setup (SQL Server, Postgres, MongoDB)
-- 🧱 Architecture patterns (Layered, DDD, Microservice-ready)
+- 🧱 Architecture patterns (Layered, Clean, Onion, DDD)
 - ⚙️ Optional services (Hangfire, Swagger, Health checks, etc.)
 - 🌐 REST or GraphQL API templates
 - 🌐 Typed HTTP clients with Refit ([example](docs/refit-http-clients.md))
@@ -42,6 +42,10 @@ This tool helps teams quickly set up new projects by automating:
 - 🚀 Azure DevOps/GitHub Actions CI templates
 - 🧪 Testing setup (xUnit, Jest, Playwright)
 - 🎨 UI with ShadCN + TailwindCSS (React Frontend)
+
+### Architecture Templates
+
+This scaffold includes template sets for **Clean**, **Layered**, **Onion**, and **DDD** architectures. Each architecture provides compatible backend and frontend folders under `templates/<architecture>`.
 
 ---
 

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -1,7 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.validateConfig = validateConfig;
-const allowedArchitectures = ["clean", "layered"];
+// supported architecture patterns for project generation
+const allowedArchitectures = ["clean", "layered", "onion", "ddd"];
 const allowedApiTypes = ["rest", "graphql"];
 function validateConfig(config) {
     var _a, _b, _c, _d, _e;

--- a/lib/configValidator.ts
+++ b/lib/configValidator.ts
@@ -28,7 +28,8 @@ export interface ValidatedConfig {
   enableCors: boolean;
 }
 
-const allowedArchitectures = ["clean", "layered"];
+// supported architecture patterns for project generation
+const allowedArchitectures = ["clean", "layered", "onion", "ddd"];
 const allowedApiTypes = ["rest", "graphql"];
 
 export function validateConfig(config: ScaffoldConfig): ValidatedConfig {

--- a/lib/structureGenerator.js
+++ b/lib/structureGenerator.js
@@ -19,6 +19,25 @@ function getArchitectureTree(name) {
         models: {},
         repositories: {}
       }
+    },
+    onion: {
+      src: {
+        domain: {},
+        application: {},
+        infrastructure: {},
+        web: {}
+      },
+      tests: {}
+    },
+    ddd: {
+      src: {
+        domain: {},
+        application: {},
+        infrastructure: {},
+        api: {},
+        shared: {}
+      },
+      tests: {}
     }
   };
   return trees[name.toLowerCase()] || trees.layered;

--- a/templates/clean/README.md
+++ b/templates/clean/README.md
@@ -1,0 +1,3 @@
+# {{projectName}}
+
+This project follows the Clean architecture and uses {{database}} as the database.

--- a/templates/clean/api/AppDbContext.cs
+++ b/templates/clean/api/AppDbContext.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/templates/clean/api/Program.cs
+++ b/templates/clean/api/Program.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var features = builder.Configuration.GetSection("Features");
+var enableAuth = features.GetValue<bool>("EnableAuth");
+var enableEf = features.GetValue<bool>("EnableEf");
+var enableSwagger = features.GetValue<bool>("EnableSwagger");
+var enableCors = features.GetValue<bool>("EnableCors");
+var enableHttpClients = features.GetValue<bool>("EnableHttpClients");
+
+if (enableAuth)
+{
+    builder.Services
+        .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+        .AddMicrosoftIdentityWebApp(options =>
+        {
+            builder.Configuration.Bind("AzureAd", options);
+            options.ResponseType = "code";
+            options.UsePkce = true;
+        });
+    builder.Services.AddAuthorization();
+}
+
+if (enableEf)
+{
+    var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+    builder.Services.AddDbContext<AppDbContext>(options =>
+        options.{{efProvider}}(connectionString));
+    builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+}
+
+builder.Services.AddControllers();
+
+if (enableHttpClients)
+{
+    builder.Services.AddHttpClient();
+    builder.Services.AddTransient(typeof(IRefitHttpClientService<>), typeof(RefitHttpClientService<>));
+}
+
+if (enableCors)
+{
+    builder.Services.AddCors(options =>
+    {
+        options.AddDefaultPolicy(policy =>
+        {
+            policy.AllowAnyOrigin()
+                  .AllowAnyHeader()
+                  .AllowAnyMethod();
+        });
+    });
+}
+
+if (enableSwagger)
+{
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen();
+}
+
+builder.Services.AddTransient<GlobalExceptionHandlingMiddleware>();
+
+var app = builder.Build();
+
+app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
+
+if (enableSwagger)
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+if (enableCors)
+{
+    app.UseCors();
+}
+
+if (enableAuth)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
+
+app.MapControllers();
+
+app.Run();
+
+public class GlobalExceptionHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionHandlingMiddleware> _logger;
+
+    public GlobalExceptionHandlingMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsJsonAsync(new { error = "An unexpected error occurred." });
+        }
+    }
+}

--- a/templates/clean/api/Repositories/GenericRepository.cs
+++ b/templates/clean/api/Repositories/GenericRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class GenericRepository<T> : IGenericRepository<T> where T : class
+{
+    private readonly AppDbContext _context;
+
+    public GenericRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<T> AddAsync(T entity)
+    {
+        _context.Set<T>().Add(entity);
+        await _context.SaveChangesAsync();
+        return entity;
+    }
+
+    public async Task DeleteAsync(T entity)
+    {
+        _context.Set<T>().Remove(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<T?> GetByIdAsync(int id)
+    {
+        return await _context.Set<T>().FindAsync(id);
+    }
+
+    public async Task<IReadOnlyList<T>> ListAsync(ISpecification<T>? spec = null)
+    {
+        var query = SpecificationEvaluator<T>.GetQuery(_context.Set<T>().AsQueryable(), spec);
+        return await query.ToListAsync();
+    }
+
+    public async Task UpdateAsync(T entity)
+    {
+        _context.Set<T>().Update(entity);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/templates/clean/api/Repositories/IGenericRepository.cs
+++ b/templates/clean/api/Repositories/IGenericRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public interface IGenericRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(int id);
+    Task<IReadOnlyList<T>> ListAsync(ISpecification<T>? spec = null);
+    Task<T> AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(T entity);
+}

--- a/templates/clean/api/Repositories/Specifications/BaseSpecification.cs
+++ b/templates/clean/api/Repositories/Specifications/BaseSpecification.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+public abstract class BaseSpecification<T> : ISpecification<T>
+{
+    public Expression<Func<T, bool>>? Criteria { get; protected set; }
+    public List<Expression<Func<T, object>>> Includes { get; } = new();
+
+    protected void AddInclude(Expression<Func<T, object>> include)
+    {
+        Includes.Add(include);
+    }
+}

--- a/templates/clean/api/Repositories/Specifications/ISpecification.cs
+++ b/templates/clean/api/Repositories/Specifications/ISpecification.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+public interface ISpecification<T>
+{
+    Expression<Func<T, bool>>? Criteria { get; }
+    List<Expression<Func<T, object>>> Includes { get; }
+}

--- a/templates/clean/api/Repositories/Specifications/SpecificationEvaluator.cs
+++ b/templates/clean/api/Repositories/Specifications/SpecificationEvaluator.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+public static class SpecificationEvaluator<T> where T : class
+{
+    public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T>? spec)
+    {
+        var query = inputQuery;
+        if (spec?.Criteria != null)
+        {
+            query = query.Where(spec.Criteria);
+        }
+        if (spec != null)
+        {
+            query = spec.Includes.Aggregate(query, (current, include) => current.Include(include));
+        }
+        return query;
+    }
+}

--- a/templates/clean/api/Services/RefitHttpClientService.cs
+++ b/templates/clean/api/Services/RefitHttpClientService.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using Microsoft.Extensions.Http;
+using Refit;
+
+public interface IRefitHttpClientService<TClient> where TClient : class
+{
+    TClient Api { get; }
+}
+
+public class RefitHttpClientService<TClient> : IRefitHttpClientService<TClient> where TClient : class
+{
+    public TClient Api { get; }
+
+    public RefitHttpClientService(IHttpClientFactory factory, IConfiguration config)
+    {
+        var baseUrl = config[$"ServiceUrls:{typeof(TClient).Name}"]; 
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException($"Base URL for {typeof(TClient).Name} not configured");
+        }
+        var httpClient = factory.CreateClient(typeof(TClient).Name);
+        httpClient.BaseAddress = new Uri(baseUrl);
+        Api = RestService.For<TClient>(httpClient);
+    }
+}

--- a/templates/clean/api/appsettings.json
+++ b/templates/clean/api/appsettings.json
@@ -1,0 +1,28 @@
+{
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "YOUR_TENANT_ID",
+    "ClientId": "YOUR_CLIENT_ID",
+    "CallbackPath": "/signin-oidc"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "{{connectionString}}"
+  },
+  "Features": {
+    "EnableAuth": {{enableAuth}},
+    "EnableEf": {{enableEf}},
+    "EnableSwagger": {{enableSwagger}},
+    "EnableCors": {{enableCors}},
+    "EnableHttpClients": {{enableHttpClients}}
+  },
+  "ServiceUrls": {
+    "ExampleApi": "https://api.example.com"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/templates/clean/config/db.txt
+++ b/templates/clean/config/db.txt
@@ -1,0 +1,1 @@
+Database: {{database}}

--- a/templates/clean/src/App.tsx
+++ b/templates/clean/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Layout from './components/Layout';
+import LoginPage from './pages/LoginPage';
+
+export default function App() {
+  return (
+    <Layout>
+      <LoginPage />
+    </Layout>
+  );
+}

--- a/templates/clean/src/auth/msalConfig.ts
+++ b/templates/clean/src/auth/msalConfig.ts
@@ -1,0 +1,14 @@
+import { Configuration } from '@azure/msal-browser';
+
+const msalConfig: Configuration = {
+  auth: {
+    clientId: process.env.REACT_APP_AZURE_CLIENT_ID as string,
+    authority: `https://login.microsoftonline.com/${process.env.REACT_APP_TENANT_ID}`,
+    redirectUri: process.env.REACT_APP_REDIRECT_URI,
+  },
+  cache: {
+    cacheLocation: 'localStorage',
+  },
+};
+
+export default msalConfig;

--- a/templates/clean/src/components/Layout.tsx
+++ b/templates/clean/src/components/Layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: Props) {
+  return (
+    <div className="min-h-screen bg-gray-100 text-gray-900">
+      <header className="p-4 bg-blue-600 text-white">My App</header>
+      <main className="p-4">{children}</main>
+    </div>
+  );
+}

--- a/templates/clean/src/index.tsx
+++ b/templates/clean/src/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { MsalProvider } from '@azure/msal-react';
+import msalConfig from './auth/msalConfig';
+
+const enableAuth = process.env.REACT_APP_ENABLE_AUTH === 'true';
+
+const Root = () => {
+  if (enableAuth) {
+    const pca = new PublicClientApplication(msalConfig);
+    return (
+      <MsalProvider instance={pca}>
+        <App />
+      </MsalProvider>
+    );
+  }
+  return <App />;
+};
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Root />
+  </React.StrictMode>
+);

--- a/templates/clean/src/pages/LoginPage.tsx
+++ b/templates/clean/src/pages/LoginPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function LoginPage() {
+  return (
+    <div className="max-w-sm mx-auto mt-10">
+      <h1 className="text-xl mb-4">Login</h1>
+      <form className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Username" />
+        <input type="password" className="border p-2 w-full" placeholder="Password" />
+        <button className="bg-blue-600 text-white px-4 py-2 w-full">Sign in</button>
+      </form>
+    </div>
+  );
+}

--- a/templates/clean/tailwind.config.js
+++ b/templates/clean/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/templates/ddd/README.md
+++ b/templates/ddd/README.md
@@ -1,0 +1,3 @@
+# {{projectName}}
+
+This project is organized using Domain-Driven Design (DDD) and uses {{database}} as the database.

--- a/templates/ddd/api/AppDbContext.cs
+++ b/templates/ddd/api/AppDbContext.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/templates/ddd/api/Program.cs
+++ b/templates/ddd/api/Program.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var features = builder.Configuration.GetSection("Features");
+var enableAuth = features.GetValue<bool>("EnableAuth");
+var enableEf = features.GetValue<bool>("EnableEf");
+var enableSwagger = features.GetValue<bool>("EnableSwagger");
+var enableCors = features.GetValue<bool>("EnableCors");
+var enableHttpClients = features.GetValue<bool>("EnableHttpClients");
+
+if (enableAuth)
+{
+    builder.Services
+        .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+        .AddMicrosoftIdentityWebApp(options =>
+        {
+            builder.Configuration.Bind("AzureAd", options);
+            options.ResponseType = "code";
+            options.UsePkce = true;
+        });
+    builder.Services.AddAuthorization();
+}
+
+if (enableEf)
+{
+    var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+    builder.Services.AddDbContext<AppDbContext>(options =>
+        options.{{efProvider}}(connectionString));
+    builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+}
+
+builder.Services.AddControllers();
+
+if (enableHttpClients)
+{
+    builder.Services.AddHttpClient();
+    builder.Services.AddTransient(typeof(IRefitHttpClientService<>), typeof(RefitHttpClientService<>));
+}
+
+if (enableCors)
+{
+    builder.Services.AddCors(options =>
+    {
+        options.AddDefaultPolicy(policy =>
+        {
+            policy.AllowAnyOrigin()
+                  .AllowAnyHeader()
+                  .AllowAnyMethod();
+        });
+    });
+}
+
+if (enableSwagger)
+{
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen();
+}
+
+builder.Services.AddTransient<GlobalExceptionHandlingMiddleware>();
+
+var app = builder.Build();
+
+app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
+
+if (enableSwagger)
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+if (enableCors)
+{
+    app.UseCors();
+}
+
+if (enableAuth)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
+
+app.MapControllers();
+
+app.Run();
+
+public class GlobalExceptionHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionHandlingMiddleware> _logger;
+
+    public GlobalExceptionHandlingMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsJsonAsync(new { error = "An unexpected error occurred." });
+        }
+    }
+}

--- a/templates/ddd/api/Repositories/GenericRepository.cs
+++ b/templates/ddd/api/Repositories/GenericRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class GenericRepository<T> : IGenericRepository<T> where T : class
+{
+    private readonly AppDbContext _context;
+
+    public GenericRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<T> AddAsync(T entity)
+    {
+        _context.Set<T>().Add(entity);
+        await _context.SaveChangesAsync();
+        return entity;
+    }
+
+    public async Task DeleteAsync(T entity)
+    {
+        _context.Set<T>().Remove(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<T?> GetByIdAsync(int id)
+    {
+        return await _context.Set<T>().FindAsync(id);
+    }
+
+    public async Task<IReadOnlyList<T>> ListAsync(ISpecification<T>? spec = null)
+    {
+        var query = SpecificationEvaluator<T>.GetQuery(_context.Set<T>().AsQueryable(), spec);
+        return await query.ToListAsync();
+    }
+
+    public async Task UpdateAsync(T entity)
+    {
+        _context.Set<T>().Update(entity);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/templates/ddd/api/Repositories/IGenericRepository.cs
+++ b/templates/ddd/api/Repositories/IGenericRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public interface IGenericRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(int id);
+    Task<IReadOnlyList<T>> ListAsync(ISpecification<T>? spec = null);
+    Task<T> AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(T entity);
+}

--- a/templates/ddd/api/Repositories/Specifications/BaseSpecification.cs
+++ b/templates/ddd/api/Repositories/Specifications/BaseSpecification.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+public abstract class BaseSpecification<T> : ISpecification<T>
+{
+    public Expression<Func<T, bool>>? Criteria { get; protected set; }
+    public List<Expression<Func<T, object>>> Includes { get; } = new();
+
+    protected void AddInclude(Expression<Func<T, object>> include)
+    {
+        Includes.Add(include);
+    }
+}

--- a/templates/ddd/api/Repositories/Specifications/ISpecification.cs
+++ b/templates/ddd/api/Repositories/Specifications/ISpecification.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+public interface ISpecification<T>
+{
+    Expression<Func<T, bool>>? Criteria { get; }
+    List<Expression<Func<T, object>>> Includes { get; }
+}

--- a/templates/ddd/api/Repositories/Specifications/SpecificationEvaluator.cs
+++ b/templates/ddd/api/Repositories/Specifications/SpecificationEvaluator.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+public static class SpecificationEvaluator<T> where T : class
+{
+    public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T>? spec)
+    {
+        var query = inputQuery;
+        if (spec?.Criteria != null)
+        {
+            query = query.Where(spec.Criteria);
+        }
+        if (spec != null)
+        {
+            query = spec.Includes.Aggregate(query, (current, include) => current.Include(include));
+        }
+        return query;
+    }
+}

--- a/templates/ddd/api/Services/RefitHttpClientService.cs
+++ b/templates/ddd/api/Services/RefitHttpClientService.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using Microsoft.Extensions.Http;
+using Refit;
+
+public interface IRefitHttpClientService<TClient> where TClient : class
+{
+    TClient Api { get; }
+}
+
+public class RefitHttpClientService<TClient> : IRefitHttpClientService<TClient> where TClient : class
+{
+    public TClient Api { get; }
+
+    public RefitHttpClientService(IHttpClientFactory factory, IConfiguration config)
+    {
+        var baseUrl = config[$"ServiceUrls:{typeof(TClient).Name}"]; 
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException($"Base URL for {typeof(TClient).Name} not configured");
+        }
+        var httpClient = factory.CreateClient(typeof(TClient).Name);
+        httpClient.BaseAddress = new Uri(baseUrl);
+        Api = RestService.For<TClient>(httpClient);
+    }
+}

--- a/templates/ddd/api/appsettings.json
+++ b/templates/ddd/api/appsettings.json
@@ -1,0 +1,28 @@
+{
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "YOUR_TENANT_ID",
+    "ClientId": "YOUR_CLIENT_ID",
+    "CallbackPath": "/signin-oidc"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "{{connectionString}}"
+  },
+  "Features": {
+    "EnableAuth": {{enableAuth}},
+    "EnableEf": {{enableEf}},
+    "EnableSwagger": {{enableSwagger}},
+    "EnableCors": {{enableCors}},
+    "EnableHttpClients": {{enableHttpClients}}
+  },
+  "ServiceUrls": {
+    "ExampleApi": "https://api.example.com"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/templates/ddd/config/db.txt
+++ b/templates/ddd/config/db.txt
@@ -1,0 +1,1 @@
+Database: {{database}}

--- a/templates/ddd/src/App.tsx
+++ b/templates/ddd/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Layout from './components/Layout';
+import LoginPage from './pages/LoginPage';
+
+export default function App() {
+  return (
+    <Layout>
+      <LoginPage />
+    </Layout>
+  );
+}

--- a/templates/ddd/src/auth/msalConfig.ts
+++ b/templates/ddd/src/auth/msalConfig.ts
@@ -1,0 +1,14 @@
+import { Configuration } from '@azure/msal-browser';
+
+const msalConfig: Configuration = {
+  auth: {
+    clientId: process.env.REACT_APP_AZURE_CLIENT_ID as string,
+    authority: `https://login.microsoftonline.com/${process.env.REACT_APP_TENANT_ID}`,
+    redirectUri: process.env.REACT_APP_REDIRECT_URI,
+  },
+  cache: {
+    cacheLocation: 'localStorage',
+  },
+};
+
+export default msalConfig;

--- a/templates/ddd/src/components/Layout.tsx
+++ b/templates/ddd/src/components/Layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: Props) {
+  return (
+    <div className="min-h-screen bg-gray-100 text-gray-900">
+      <header className="p-4 bg-blue-600 text-white">My App</header>
+      <main className="p-4">{children}</main>
+    </div>
+  );
+}

--- a/templates/ddd/src/index.tsx
+++ b/templates/ddd/src/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { MsalProvider } from '@azure/msal-react';
+import msalConfig from './auth/msalConfig';
+
+const enableAuth = process.env.REACT_APP_ENABLE_AUTH === 'true';
+
+const Root = () => {
+  if (enableAuth) {
+    const pca = new PublicClientApplication(msalConfig);
+    return (
+      <MsalProvider instance={pca}>
+        <App />
+      </MsalProvider>
+    );
+  }
+  return <App />;
+};
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Root />
+  </React.StrictMode>
+);

--- a/templates/ddd/src/pages/LoginPage.tsx
+++ b/templates/ddd/src/pages/LoginPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function LoginPage() {
+  return (
+    <div className="max-w-sm mx-auto mt-10">
+      <h1 className="text-xl mb-4">Login</h1>
+      <form className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Username" />
+        <input type="password" className="border p-2 w-full" placeholder="Password" />
+        <button className="bg-blue-600 text-white px-4 py-2 w-full">Sign in</button>
+      </form>
+    </div>
+  );
+}

--- a/templates/ddd/tailwind.config.js
+++ b/templates/ddd/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/templates/onion/README.md
+++ b/templates/onion/README.md
@@ -1,0 +1,3 @@
+# {{projectName}}
+
+This project follows the Onion architecture and uses {{database}} as the database.

--- a/templates/onion/api/AppDbContext.cs
+++ b/templates/onion/api/AppDbContext.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/templates/onion/api/Program.cs
+++ b/templates/onion/api/Program.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var features = builder.Configuration.GetSection("Features");
+var enableAuth = features.GetValue<bool>("EnableAuth");
+var enableEf = features.GetValue<bool>("EnableEf");
+var enableSwagger = features.GetValue<bool>("EnableSwagger");
+var enableCors = features.GetValue<bool>("EnableCors");
+var enableHttpClients = features.GetValue<bool>("EnableHttpClients");
+
+if (enableAuth)
+{
+    builder.Services
+        .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+        .AddMicrosoftIdentityWebApp(options =>
+        {
+            builder.Configuration.Bind("AzureAd", options);
+            options.ResponseType = "code";
+            options.UsePkce = true;
+        });
+    builder.Services.AddAuthorization();
+}
+
+if (enableEf)
+{
+    var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+    builder.Services.AddDbContext<AppDbContext>(options =>
+        options.{{efProvider}}(connectionString));
+    builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+}
+
+builder.Services.AddControllers();
+
+if (enableHttpClients)
+{
+    builder.Services.AddHttpClient();
+    builder.Services.AddTransient(typeof(IRefitHttpClientService<>), typeof(RefitHttpClientService<>));
+}
+
+if (enableCors)
+{
+    builder.Services.AddCors(options =>
+    {
+        options.AddDefaultPolicy(policy =>
+        {
+            policy.AllowAnyOrigin()
+                  .AllowAnyHeader()
+                  .AllowAnyMethod();
+        });
+    });
+}
+
+if (enableSwagger)
+{
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen();
+}
+
+builder.Services.AddTransient<GlobalExceptionHandlingMiddleware>();
+
+var app = builder.Build();
+
+app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
+
+if (enableSwagger)
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+if (enableCors)
+{
+    app.UseCors();
+}
+
+if (enableAuth)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
+
+app.MapControllers();
+
+app.Run();
+
+public class GlobalExceptionHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionHandlingMiddleware> _logger;
+
+    public GlobalExceptionHandlingMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsJsonAsync(new { error = "An unexpected error occurred." });
+        }
+    }
+}

--- a/templates/onion/api/Repositories/GenericRepository.cs
+++ b/templates/onion/api/Repositories/GenericRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class GenericRepository<T> : IGenericRepository<T> where T : class
+{
+    private readonly AppDbContext _context;
+
+    public GenericRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<T> AddAsync(T entity)
+    {
+        _context.Set<T>().Add(entity);
+        await _context.SaveChangesAsync();
+        return entity;
+    }
+
+    public async Task DeleteAsync(T entity)
+    {
+        _context.Set<T>().Remove(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<T?> GetByIdAsync(int id)
+    {
+        return await _context.Set<T>().FindAsync(id);
+    }
+
+    public async Task<IReadOnlyList<T>> ListAsync(ISpecification<T>? spec = null)
+    {
+        var query = SpecificationEvaluator<T>.GetQuery(_context.Set<T>().AsQueryable(), spec);
+        return await query.ToListAsync();
+    }
+
+    public async Task UpdateAsync(T entity)
+    {
+        _context.Set<T>().Update(entity);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/templates/onion/api/Repositories/IGenericRepository.cs
+++ b/templates/onion/api/Repositories/IGenericRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public interface IGenericRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(int id);
+    Task<IReadOnlyList<T>> ListAsync(ISpecification<T>? spec = null);
+    Task<T> AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(T entity);
+}

--- a/templates/onion/api/Repositories/Specifications/BaseSpecification.cs
+++ b/templates/onion/api/Repositories/Specifications/BaseSpecification.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+public abstract class BaseSpecification<T> : ISpecification<T>
+{
+    public Expression<Func<T, bool>>? Criteria { get; protected set; }
+    public List<Expression<Func<T, object>>> Includes { get; } = new();
+
+    protected void AddInclude(Expression<Func<T, object>> include)
+    {
+        Includes.Add(include);
+    }
+}

--- a/templates/onion/api/Repositories/Specifications/ISpecification.cs
+++ b/templates/onion/api/Repositories/Specifications/ISpecification.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+public interface ISpecification<T>
+{
+    Expression<Func<T, bool>>? Criteria { get; }
+    List<Expression<Func<T, object>>> Includes { get; }
+}

--- a/templates/onion/api/Repositories/Specifications/SpecificationEvaluator.cs
+++ b/templates/onion/api/Repositories/Specifications/SpecificationEvaluator.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+public static class SpecificationEvaluator<T> where T : class
+{
+    public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T>? spec)
+    {
+        var query = inputQuery;
+        if (spec?.Criteria != null)
+        {
+            query = query.Where(spec.Criteria);
+        }
+        if (spec != null)
+        {
+            query = spec.Includes.Aggregate(query, (current, include) => current.Include(include));
+        }
+        return query;
+    }
+}

--- a/templates/onion/api/Services/RefitHttpClientService.cs
+++ b/templates/onion/api/Services/RefitHttpClientService.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using Microsoft.Extensions.Http;
+using Refit;
+
+public interface IRefitHttpClientService<TClient> where TClient : class
+{
+    TClient Api { get; }
+}
+
+public class RefitHttpClientService<TClient> : IRefitHttpClientService<TClient> where TClient : class
+{
+    public TClient Api { get; }
+
+    public RefitHttpClientService(IHttpClientFactory factory, IConfiguration config)
+    {
+        var baseUrl = config[$"ServiceUrls:{typeof(TClient).Name}"]; 
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException($"Base URL for {typeof(TClient).Name} not configured");
+        }
+        var httpClient = factory.CreateClient(typeof(TClient).Name);
+        httpClient.BaseAddress = new Uri(baseUrl);
+        Api = RestService.For<TClient>(httpClient);
+    }
+}

--- a/templates/onion/api/appsettings.json
+++ b/templates/onion/api/appsettings.json
@@ -1,0 +1,28 @@
+{
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "YOUR_TENANT_ID",
+    "ClientId": "YOUR_CLIENT_ID",
+    "CallbackPath": "/signin-oidc"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "{{connectionString}}"
+  },
+  "Features": {
+    "EnableAuth": {{enableAuth}},
+    "EnableEf": {{enableEf}},
+    "EnableSwagger": {{enableSwagger}},
+    "EnableCors": {{enableCors}},
+    "EnableHttpClients": {{enableHttpClients}}
+  },
+  "ServiceUrls": {
+    "ExampleApi": "https://api.example.com"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/templates/onion/config/db.txt
+++ b/templates/onion/config/db.txt
@@ -1,0 +1,1 @@
+Database: {{database}}

--- a/templates/onion/src/App.tsx
+++ b/templates/onion/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Layout from './components/Layout';
+import LoginPage from './pages/LoginPage';
+
+export default function App() {
+  return (
+    <Layout>
+      <LoginPage />
+    </Layout>
+  );
+}

--- a/templates/onion/src/auth/msalConfig.ts
+++ b/templates/onion/src/auth/msalConfig.ts
@@ -1,0 +1,14 @@
+import { Configuration } from '@azure/msal-browser';
+
+const msalConfig: Configuration = {
+  auth: {
+    clientId: process.env.REACT_APP_AZURE_CLIENT_ID as string,
+    authority: `https://login.microsoftonline.com/${process.env.REACT_APP_TENANT_ID}`,
+    redirectUri: process.env.REACT_APP_REDIRECT_URI,
+  },
+  cache: {
+    cacheLocation: 'localStorage',
+  },
+};
+
+export default msalConfig;

--- a/templates/onion/src/components/Layout.tsx
+++ b/templates/onion/src/components/Layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: Props) {
+  return (
+    <div className="min-h-screen bg-gray-100 text-gray-900">
+      <header className="p-4 bg-blue-600 text-white">My App</header>
+      <main className="p-4">{children}</main>
+    </div>
+  );
+}

--- a/templates/onion/src/index.tsx
+++ b/templates/onion/src/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { MsalProvider } from '@azure/msal-react';
+import msalConfig from './auth/msalConfig';
+
+const enableAuth = process.env.REACT_APP_ENABLE_AUTH === 'true';
+
+const Root = () => {
+  if (enableAuth) {
+    const pca = new PublicClientApplication(msalConfig);
+    return (
+      <MsalProvider instance={pca}>
+        <App />
+      </MsalProvider>
+    );
+  }
+  return <App />;
+};
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Root />
+  </React.StrictMode>
+);

--- a/templates/onion/src/pages/LoginPage.tsx
+++ b/templates/onion/src/pages/LoginPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function LoginPage() {
+  return (
+    <div className="max-w-sm mx-auto mt-10">
+      <h1 className="text-xl mb-4">Login</h1>
+      <form className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Username" />
+        <input type="password" className="border p-2 w-full" placeholder="Password" />
+        <button className="bg-blue-600 text-white px-4 py-2 w-full">Sign in</button>
+      </form>
+    </div>
+  );
+}

--- a/templates/onion/tailwind.config.js
+++ b/templates/onion/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tests/structureGenerator.test.ts
+++ b/tests/structureGenerator.test.ts
@@ -17,4 +17,11 @@ describe('generateStructure', () => {
     expect(vol.existsSync(path.join(base, 'src/controllers'))).toBe(true);
     expect(vol.existsSync(path.join(base, 'src/services'))).toBe(true);
   });
+
+  it('creates onion structure', async () => {
+    await generateStructure({ projectName: 'onionProj', architecture: 'onion' });
+    const base = path.resolve(process.cwd(), 'onionProj');
+    expect(vol.existsSync(path.join(base, 'src/domain'))).toBe(true);
+    expect(vol.existsSync(path.join(base, 'src/web'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add Onion and DDD architecture support
- copy templates per architecture and update CLI to use them
- document available architectures in README/docs
- update structure generator and tests for new architectures

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f6f97858883258ca27771d392e16b