### PR TITLE
Add VS Code extension for interactive scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ You will be prompted for:
 6. Architecture Pattern
 7. Optional Features
 
+### Option 2: VS Code Extension
+
+1. Install the extension from the `vscode-extension` folder using `vsce package` or by loading it as an extension during development.
+2. Run the command **Create Internal Project** from the command palette.
+3. Follow the interactive prompts to select the backend, frontend, database and optional features.
+4. The extension generates a temporary config file and runs the CLI in a terminal window.
+
+
 ---
 
 ## 🧾 Output Example
@@ -128,7 +136,8 @@ npx internal-scaffold init --config configs/dotnet-react-sqlserver.json
 
 ## 💡 Future Roadmap
 
-- VSCode extension for scaffolding UI
+The repository already ships with a VS Code extension found in `vscode-extension/`.
+Use it for an interactive scaffolding experience directly inside the editor.
 - Plugin system for custom features
 - Enterprise boilerplate templates
 - AI assistant (via Codex) for feature guidance

--- a/vscode-extension/dist/extension.js
+++ b/vscode-extension/dist/extension.js
@@ -1,0 +1,98 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.activate = activate;
+exports.deactivate = deactivate;
+const vscode = __importStar(require("vscode"));
+const fs = __importStar(require("fs"));
+const os = __importStar(require("os"));
+const path = __importStar(require("path"));
+function activate(context) {
+    const disposable = vscode.commands.registerCommand('internalScaffold.createProject', async () => {
+        var _a, _b, _c, _d, _e, _f;
+        try {
+            const config = {};
+            config.projectName = await vscode.window.showInputBox({ prompt: 'Project name' });
+            if (!config.projectName) {
+                throw new Error('Project name is required');
+            }
+            config.backend = await vscode.window.showQuickPick(['.NET 8', 'Node.js', 'None'], { placeHolder: 'Select backend' });
+            if (!config.backend) {
+                throw new Error('Backend technology is required');
+            }
+            config.frontend = await vscode.window.showQuickPick(['React', 'Blazor', 'None'], { placeHolder: 'Select frontend framework' });
+            if (!config.frontend) {
+                throw new Error('Frontend framework is required');
+            }
+            config.database = await vscode.window.showQuickPick(['SQL Server', 'Postgres', 'MongoDB', 'None'], { placeHolder: 'Select database' });
+            if (!config.database) {
+                throw new Error('Database selection is required');
+            }
+            config.apiType = (_a = await vscode.window.showQuickPick(['rest', 'graphql'], { placeHolder: 'API type' })) !== null && _a !== void 0 ? _a : 'rest';
+            config.architecture = (_b = await vscode.window.showQuickPick(['clean', 'layered', 'onion', 'ddd'], { placeHolder: 'Architecture pattern' })) !== null && _b !== void 0 ? _b : 'layered';
+            const featureOptions = [{ label: 'Azure AD Auth' }];
+            if (config.backend !== 'None') {
+                featureOptions.push({ label: 'Entity Framework' });
+                featureOptions.push({ label: 'Typed HTTP Clients' });
+                featureOptions.push({ label: 'Swagger' });
+                featureOptions.push({ label: 'CORS' });
+            }
+            const features = await vscode.window.showQuickPick(featureOptions, { canPickMany: true, placeHolder: 'Optional features' }) || [];
+            config.enableAuth = features.some(f => f.label === 'Azure AD Auth');
+            config.enableEf = features.some(f => f.label === 'Entity Framework');
+            config.enableHttpClients = features.some(f => f.label === 'Typed HTTP Clients');
+            config.enableSwagger = features.some(f => f.label === 'Swagger');
+            config.enableCors = features.some(f => f.label === 'CORS');
+            if (config.enableAuth) {
+                config.azureTenantId = (_c = await vscode.window.showInputBox({ prompt: 'Azure Tenant ID', ignoreFocusOut: true })) !== null && _c !== void 0 ? _c : '';
+                config.azureClientId = (_d = await vscode.window.showInputBox({ prompt: 'Azure Client ID', ignoreFocusOut: true })) !== null && _d !== void 0 ? _d : '';
+                config.azureClientSecret = (_e = await vscode.window.showInputBox({ prompt: 'Azure Client Secret', password: true, ignoreFocusOut: true })) !== null && _e !== void 0 ? _e : '';
+            }
+            if (config.enableEf) {
+                config.connectionString = (_f = await vscode.window.showInputBox({ prompt: 'Database connection string', ignoreFocusOut: true })) !== null && _f !== void 0 ? _f : '';
+            }
+            const tempFile = path.join(os.tmpdir(), `scaffold-${Date.now()}.json`);
+            await fs.promises.writeFile(tempFile, JSON.stringify(config, null, 2));
+            const terminal = vscode.window.createTerminal('Internal Scaffold');
+            terminal.show();
+            terminal.sendText(`npx internal-scaffold init --config "${tempFile}"`);
+        }
+        catch (err) {
+            vscode.window.showErrorMessage(`Scaffolding failed: ${err.message}`);
+        }
+    });
+    context.subscriptions.push(disposable);
+}
+function deactivate() { }

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "internal-scaffold-extension",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "internal-scaffold-extension",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "@types/vscode": "^1.74.0",
+        "typescript": "^5.0.4"
+      },
+      "engines": {
+        "vscode": "^1.74.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.112",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
+      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "internal-scaffold-extension",
+  "displayName": "Internal Project Scaffolding",
+  "description": "VS Code extension to generate projects using internal-scaffold CLI",
+  "version": "0.0.1",
+  "publisher": "internal",
+  "engines": {
+    "vscode": "^1.74.0"
+  },
+  "main": "./dist/extension.js",
+  "scripts": {
+    "compile": "tsc -p ./"
+  },
+  "activationEvents": [
+    "onCommand:internalScaffold.createProject"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "internalScaffold.createProject",
+        "title": "Create Internal Project"
+      }
+    ]
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "@types/vscode": "^1.74.0",
+    "typescript": "^5.0.4"
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export function activate(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('internalScaffold.createProject', async () => {
+    try {
+      const config: any = {};
+
+      config.projectName = await vscode.window.showInputBox({ prompt: 'Project name' });
+      if (!config.projectName) { throw new Error('Project name is required'); }
+
+      config.backend = await vscode.window.showQuickPick(['.NET 8', 'Node.js', 'None'], { placeHolder: 'Select backend' });
+      if (!config.backend) { throw new Error('Backend technology is required'); }
+
+      config.frontend = await vscode.window.showQuickPick(['React', 'Blazor', 'None'], { placeHolder: 'Select frontend framework' });
+      if (!config.frontend) { throw new Error('Frontend framework is required'); }
+
+      config.database = await vscode.window.showQuickPick(['SQL Server', 'Postgres', 'MongoDB', 'None'], { placeHolder: 'Select database' });
+      if (!config.database) { throw new Error('Database selection is required'); }
+
+      config.apiType = await vscode.window.showQuickPick(['rest', 'graphql'], { placeHolder: 'API type' }) ?? 'rest';
+      config.architecture = await vscode.window.showQuickPick(['clean', 'layered', 'onion', 'ddd'], { placeHolder: 'Architecture pattern' }) ?? 'layered';
+
+      const featureOptions = [{ label: 'Azure AD Auth' }];
+      if (config.backend !== 'None') {
+        featureOptions.push({ label: 'Entity Framework' });
+        featureOptions.push({ label: 'Typed HTTP Clients' });
+        featureOptions.push({ label: 'Swagger' });
+        featureOptions.push({ label: 'CORS' });
+      }
+
+      const features = await vscode.window.showQuickPick(featureOptions, { canPickMany: true, placeHolder: 'Optional features' }) || [];
+
+      config.enableAuth = features.some(f => f.label === 'Azure AD Auth');
+      config.enableEf = features.some(f => f.label === 'Entity Framework');
+      config.enableHttpClients = features.some(f => f.label === 'Typed HTTP Clients');
+      config.enableSwagger = features.some(f => f.label === 'Swagger');
+      config.enableCors = features.some(f => f.label === 'CORS');
+
+      if (config.enableAuth) {
+        config.azureTenantId = await vscode.window.showInputBox({ prompt: 'Azure Tenant ID', ignoreFocusOut: true }) ?? '';
+        config.azureClientId = await vscode.window.showInputBox({ prompt: 'Azure Client ID', ignoreFocusOut: true }) ?? '';
+        config.azureClientSecret = await vscode.window.showInputBox({ prompt: 'Azure Client Secret', password: true, ignoreFocusOut: true }) ?? '';
+      }
+
+      if (config.enableEf) {
+        config.connectionString = await vscode.window.showInputBox({ prompt: 'Database connection string', ignoreFocusOut: true }) ?? '';
+      }
+
+      const tempFile = path.join(os.tmpdir(), `scaffold-${Date.now()}.json`);
+      await fs.promises.writeFile(tempFile, JSON.stringify(config, null, 2));
+
+      const terminal = vscode.window.createTerminal('Internal Scaffold');
+      terminal.show();
+      terminal.sendText(`npx internal-scaffold init --config "${tempFile}"`);
+    } catch (err: any) {
+      vscode.window.showErrorMessage(`Scaffolding failed: ${err.message}`);
+    }
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "lib": ["es2019"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add VS Code extension under `vscode-extension` for running the scaffolding CLI
- describe usage of the extension in the README
- note extension availability in the roadmap

## Testing
- `npm run compile --silent` in `vscode-extension`
- `npm install --silent`
- `npx jest tests/configValidator.test.ts --runInBand`
- `npx jest tests/structureGenerator.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_685f7867d0488325aae02779cb695920