### PR TITLE
Add status page to generated projects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,12 @@ Package the extension using `vsce package` and install the resulting `.vsix` fil
   README.md
 ```
 
+### Verifying your Setup
+
+After running the generated services, open the React UI. The home page shows a
+status checklist by calling the `/status` API endpoint to confirm that features
+like the database connection and authentication are working.
+
 The `configs/` directory contains additional ready‑made configuration files for common combinations of backend, frontend and database.
 
 ---

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,3 +1,7 @@
 # {{projectName}}
 
 This project uses {{database}} as the database.
+
+Run the backend and frontend and then open the UI in your browser. The home page
+will call the `/status` endpoint to verify that features like the database
+connection and authentication are configured correctly.

--- a/templates/api/Controllers/StatusController.cs
+++ b/templates/api/Controllers/StatusController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Authorization;
+
+[ApiController]
+[Route("[controller]")]
+public class StatusController : ControllerBase
+{
+    private readonly IConfiguration _config;
+    private readonly IServiceProvider _services;
+
+    public StatusController(IConfiguration config, IServiceProvider services)
+    {
+        _config = config;
+        _services = services;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var features = _config.GetSection("Features");
+        bool enableEf = features.GetValue<bool>("EnableEf");
+        bool dbConnected = false;
+
+        if (enableEf)
+        {
+            using var scope = _services.CreateScope();
+            var db = scope.ServiceProvider.GetService<AppDbContext>();
+            if (db != null)
+            {
+                try
+                {
+                    dbConnected = await db.Database.CanConnectAsync();
+                }
+                catch
+                {
+                    dbConnected = false;
+                }
+            }
+        }
+
+        var result = new
+        {
+            enableAuth = features.GetValue<bool>("EnableAuth"),
+            enableEf,
+            enableSwagger = features.GetValue<bool>("EnableSwagger"),
+            enableCors = features.GetValue<bool>("EnableCors"),
+            enableHttpClients = features.GetValue<bool>("EnableHttpClients"),
+            dbConnected,
+            authenticated = User?.Identity?.IsAuthenticated == true,
+            user = User?.Identity?.IsAuthenticated == true ? User.Identity?.Name : null
+        };
+
+        return Ok(result);
+    }
+}
+

--- a/templates/src/App.tsx
+++ b/templates/src/App.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import Layout from './components/Layout';
 import LoginPage from './pages/LoginPage';
+import StatusPage from './pages/StatusPage';
+
+const enableAuth = process.env.REACT_APP_ENABLE_AUTH === 'true';
 
 export default function App() {
   return (
     <Layout>
-      <LoginPage />
+      <StatusPage />
+      {enableAuth && <LoginPage />}
     </Layout>
   );
 }

--- a/templates/src/pages/StatusPage.tsx
+++ b/templates/src/pages/StatusPage.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+
+interface StatusInfo {
+  enableAuth: boolean;
+  enableEf: boolean;
+  enableSwagger: boolean;
+  enableCors: boolean;
+  enableHttpClients: boolean;
+  dbConnected: boolean;
+  authenticated: boolean;
+  user?: string | null;
+}
+
+export default function StatusPage() {
+  const [status, setStatus] = useState<StatusInfo | null>(null);
+
+  useEffect(() => {
+    fetch('/status')
+      .then((res) => res.json())
+      .then(setStatus)
+      .catch(() => setStatus(null));
+  }, []);
+
+  if (!status) {
+    return <p>Loading status...</p>;
+  }
+
+  return (
+    <div className="max-w-lg mx-auto mt-10 space-y-2">
+      <h1 className="text-xl mb-4">Project Status</h1>
+      <ul className="space-y-1">
+        <li>
+          <label>
+            <input type="checkbox" checked={status.enableAuth} readOnly /> Authentication enabled
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" checked={status.dbConnected} readOnly /> Database connection
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" checked={status.enableSwagger} readOnly /> Swagger
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" checked={status.enableCors} readOnly /> CORS
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" checked={status.enableHttpClients} readOnly /> HttpClients
+          </label>
+        </li>
+        {status.user && <li>Logged in as {status.user}</li>}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create React StatusPage and serve it on app homepage
- add API StatusController to check DB connection and auth status
- mention status page in template README and docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8028845483258752f5a0ce063362